### PR TITLE
Fix programming language shown on GitHub to Ruby

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* linguist-vendored
+*.rb linguist-vendored=false


### PR DESCRIPTION
The programming language currently showing on GitHub for this repository is 'HTML'.  This changes it to 'Ruby'